### PR TITLE
Add Modeshape variable; syntax fix

### DIFF
--- a/compose.tf
+++ b/compose.tf
@@ -194,11 +194,12 @@ resource "null_resource" "install_docker_on_compose" {
     }
 
     content = <<EOF
-FEDORA_OPTIONS=-Dfcrepo.modeshape.configuration=classpath:/config/jdbc-postgresql-s3/repository${var.fcrepo_db_ssl ? "-ssl" : ""}.json -Dfcrepo.postgresql.host=${module.db_fcrepo.this_db_instance_address} -Dfcrepo.postgresql.username=${module.db_fcrepo.this_db_instance_username} -Dfcrepo.postgresql.password=${module.db_fcrepo.this_db_instance_password} -Dfcrepo.postgresql.port=${module.db_fcrepo.this_db_instance_port} -Daws.accessKeyId=${var.fcrepo_binary_bucket_access_key} -Daws.secretKey=${var.fcrepo_binary_bucket_secret_key} -Daws.bucket=${aws_s3_bucket.fcrepo_binary_bucket.id}
+FEDORA_OPTIONS=-Dfcrepo.postgresql.host=${module.db_fcrepo.this_db_instance_address} -Dfcrepo.postgresql.username=${module.db_fcrepo.this_db_instance_username} -Dfcrepo.postgresql.password=${module.db_fcrepo.this_db_instance_password} -Dfcrepo.postgresql.port=${module.db_fcrepo.this_db_instance_port} -Daws.accessKeyId=${var.fcrepo_binary_bucket_access_key} -Daws.secretKey=${var.fcrepo_binary_bucket_secret_key} -Daws.bucket=${aws_s3_bucket.fcrepo_binary_bucket.id}
 FEDORA_LOGGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/fedora.log
+FEDORA_MODESHAPE_CONFIG=classpath:/config/jdbc-postgresql-s3/repository${var.fcrepo_db_ssl ? "-ssl" : ""}.json
 
 SOLR_LOGGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/solr.log
-S3_HELPER_LOGROUP==${aws_cloudwatch_log_group.compose_log_group.name}/s3-helper.log
+S3_HELPER_LOGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/s3-helper.log
 HLS_LOGGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/hls.log
 AVALON_STREAMING_BUCKET=${aws_s3_bucket.this_derivatives.id}
 AVALON_LOGGROUP=${aws_cloudwatch_log_group.compose_log_group.name}/avalon.log

--- a/modules/password/main.tf
+++ b/modules/password/main.tf
@@ -7,5 +7,5 @@ resource "random_string" "result" {
 }
 
 output "result" {
-  value = "${random_string.result.result}"
+  value = random_string.result.result
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -63,6 +63,7 @@ output "db_avalon_username" {
 
 output "db_avalon_password" {
   value = module.db_avalon.this_db_instance_password
+  sensitive = true
 }
 
 output "db_fcrepo_address" {
@@ -79,6 +80,7 @@ output "db_fcrepo_username" {
 
 output "db_fcrepo_password" {
   value = module.db_fcrepo.this_db_instance_password
+  sensitive = true
 }
 
 output "selected_subnets" {

--- a/vpc_data.tf
+++ b/vpc_data.tf
@@ -28,6 +28,6 @@ locals {
     aws_subnet_arns = [for s in data.aws_subnet.selected : s.arn ]
     application_fqdn_list = split(".", var.application_fqdn)
     appended_fqdn_list = terraform.workspace == "prod" ? local.application_fqdn_list : formatlist("%s-${terraform.workspace}", local.application_fqdn_list)
-    appended_fqdn = replace(var.application_fqdn, local.application_fqdn_list[var.application_fqdn_workspace_insertion_index], "${local.appended_fqdn_list[var.application_fqdn_workspace_insertion_index]}")
+    appended_fqdn = replace(var.application_fqdn, local.application_fqdn_list[var.application_fqdn_workspace_insertion_index], local.appended_fqdn_list[var.application_fqdn_workspace_insertion_index])
     streaming_appended_fqdn = replace(local.appended_fqdn, local.appended_fqdn_list[var.application_fqdn_workspace_insertion_index], "streaming.${local.appended_fqdn_list[var.application_fqdn_workspace_insertion_index]}")
 }


### PR DESCRIPTION
This commit will add a fedora modeshape config environment variable that will allow either SSL or HTTP postgres DB connections. Also removes an extra = that was causing errors.