### PR TITLE
Add google tracking id as optional variable

### DIFF
--- a/compose.tf
+++ b/compose.tf
@@ -227,6 +227,7 @@ STREAMING_HOST=${local.streaming_appended_fqdn}
 SETTINGS__STREAMING__HTTP_BASE=https://${local.streaming_appended_fqdn}/avalon
 SETTINGS__TIMELINER__TIMELINER_URL=https://${local.appended_fqdn}/timeliner
 SETTINGS__INITIAL_USER=${var.avalon_admin}
+TRACKING_ID=${var.tracking_id}
 ##### LTI Integration Variables ################
 LTI_AUTH_KEY=${var.lti_auth_key}
 LTI_AUTH_SECRET=${var.lti_auth_secret}

--- a/readme/avalon_variables.md
+++ b/readme/avalon_variables.md
@@ -4,7 +4,7 @@
 | assertion\_cs\_url | The URL at which the SAML assertion should be received. If not provided, defaults to the OmniAuth callback URL | `string` | `""` | no |
 | assertion\_logout\_url | n/a | `string` | `""` | no |
 | csp\_frame\_ancestors | Sets allowed urls for the Content Security Policy header | `string` | `""` | no |
-| fedora\_ssl | Forces the fedora database connection to use ssl. | `bool` | `false` | no |
+| fcrepo\_db\_ssl | Forces the fedora database connection to use ssl. | `bool` | `false` | no |
 | idp\_cert\_file | Path to IDP's cert, cert should be in PEM format. | `string` | `""` | no |
 | idp\_slo\_target\_url | The URL to which the single logout request and response should be sent. This would be on the identity provider. | `string` | `""` | no |
 | idp\_sso\_target\_url | The URL to which the authentication request should be sent. This would be on the identity provider. | `string` | `""` | no |
@@ -14,3 +14,4 @@
 | secret\_key\_base | Rails application's secret key, should be unique per environment. Default redacted from table for formatting | `string` | `"redacted"` | no |
 | sp\_cert\_file | Path to the service provider's cert, in standard PEM format. | `string` | `""` | no |
 | sp\_key\_file | Path to the service provider's private key, in standard PEM format. | `string` | `""` | no |
+| tracking\_id | Google Analytics Tracking ID | `string` | `""` | no |

--- a/variables-02-avalon-env.tf
+++ b/variables-02-avalon-env.tf
@@ -68,3 +68,7 @@ variable "sp_key_file" {
   description = "Path to the service provider's private key, in standard PEM format."
 }
 
+variable "tracking_id" {
+    default = ""
+    description = "Google Analytics Tracking ID"
+}


### PR DESCRIPTION
This commit adds the Google Analytics Tracking ID. It is an optional variable.