### PR TITLE
Add 'prod2' as secondary prod workspace

### DIFF
--- a/readme/aws_var.md
+++ b/readme/aws_var.md
@@ -2,7 +2,7 @@
 |------|-------------|------|---------|:--------:|
 | app\_name | n/a | `string` | `"avalon"` | no |
 | application\_fqdn | The fully qualified production domain name. This is name is used only by the application load balancer, not route53.<br>    Note that the template will also create another domain name for streaming that is streaming.{application\_fqdn}. | `string` | n/a | yes |
-| application\_fqdn\_workspace\_insertion\_index | The application fqdn is split into a list at each '.', this variable is the index (first object is 0) where the workspace will be appended.<br>    For example if the application fqdn is 'avr.emory.edu', this variable is set to 0, and the workspace is test, the output will be avr-test.emory.edu.<br>    If the workspace is 'prod' then nothing is appended to the fqdn and the address on the alb would be 'avr.emory.edu'. | `number` | `0` | no |
+| application\_fqdn\_workspace\_insertion\_index | The application fqdn is split into a list at each '.', this variable is the index (first object is 0) where the workspace will be appended.<br>    For example if the application fqdn is 'avr.emory.edu', this variable is set to 0, and the workspace is test, the output will be avr-test.emory.edu.<br>    If the workspace is 'prod' or 'prod2' then nothing is appended to the fqdn and the address on the alb would be 'avr.emory.edu'. | `number` | `0` | no |
 | avalon\_admin | n/a | `string` | `"admin@example.com"` | no |
 | avalon\_branch | Controls which github branch of the avalon repo is used by AWS CodeBuild | `string` | `"main"` | no |
 | avalon\_repo | Determines what github repo AWS CodeBuild builds from | `string` | `"https://github.com/emory-libraries/avalon"` | no |

--- a/variables-01-aws.tf
+++ b/variables-01-aws.tf
@@ -37,7 +37,7 @@ variable "application_fqdn_workspace_insertion_index" {
   description = <<EOF
     The application fqdn is split into a list at each '.', this variable is the index (first object is 0) where the workspace will be appended.
     For example if the application fqdn is 'avr.emory.edu', this variable is set to 0, and the workspace is test, the output will be avr-test.emory.edu.
-    If the workspace is 'prod' then nothing is appended to the fqdn and the address on the alb would be 'avr.emory.edu'. 
+    If the workspace is 'prod' or 'prod2' then nothing is appended to the fqdn and the address on the alb would be 'avr.emory.edu'. 
     EOF
 }
 variable "bastion_instance_type" {

--- a/vpc_data.tf
+++ b/vpc_data.tf
@@ -27,7 +27,7 @@ data "aws_subnet" "selected" {
 locals {
     aws_subnet_arns = [for s in data.aws_subnet.selected : s.arn ]
     application_fqdn_list = split(".", var.application_fqdn)
-    appended_fqdn_list = terraform.workspace == "prod" ? local.application_fqdn_list : formatlist("%s-${terraform.workspace}", local.application_fqdn_list)
+    appended_fqdn_list = terraform.workspace == "prod" || terraform.workspace == "prod2" ? local.application_fqdn_list : formatlist("%s-${terraform.workspace}", local.application_fqdn_list)
     appended_fqdn = replace(var.application_fqdn, local.application_fqdn_list[var.application_fqdn_workspace_insertion_index], local.appended_fqdn_list[var.application_fqdn_workspace_insertion_index])
     streaming_appended_fqdn = replace(local.appended_fqdn, local.appended_fqdn_list[var.application_fqdn_workspace_insertion_index], "streaming.${local.appended_fqdn_list[var.application_fqdn_workspace_insertion_index]}")
     aws_secret_yaml_file = file(var.fcrepo_binary_bucket_yaml_file)


### PR DESCRIPTION
This commit will add prod2 as a secondary workspace, with the same logic as the 'prod' workspace. Also add optional variable tracking_id.